### PR TITLE
Improve SKILL.md activation and authoring quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ heurist-mesh-skill/
 └── references/
     ├── heurist-api-key.md            # Credit purchase, free tweet claim, API key auth
     ├── x402-payment.md               # On-chain USDC payment on Base
-    └── inflow-payment.md             # Pay with Inflow (currently in testnet)
+    ├── inflow-payment.md             # Pay with Inflow (currently in testnet)
+    └── discover-agents.md            # Full agent registry discovery workflow
 ```
 
 ## Recommended Agents

--- a/README.md
+++ b/README.md
@@ -8,11 +8,21 @@ Access Web3 and crypto intelligence via [Heurist Mesh](https://mesh.heurist.ai) 
 
 ## Quick Start
 
-Paste this into Claude Code, Cursor, Codex, OpenClaw, or any AI agent that supports SKILL.md:
+### Install via Skills CLI (Recommended)
+
+```bash
+npx skills add heurist-network/heurist-mesh-skill
+```
+
+This works with Claude Code, OpenCode, Cursor, Codex, Cline, Windsurf, and [37+ other agents](https://github.com/vercel-labs/skills#supported-agents).
+
+### Manual
+
+Paste this into any AI agent that supports SKILL.md:
 
 > Clone https://github.com/heurist-network/heurist-mesh-skill, read SKILL.md, and help me query crypto data
 
-The agent will read the skill, fetches tool schemas, and become a crypto analyst.
+The agent will read the skill, fetch tool schemas, and become a crypto analyst.
 
 ## Structure
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: heurist-mesh-skill
 description: Access real-time crypto token data, DeFi analytics, wallet intelligence, project research, and blockchain insights through Heurist Mesh agents. Use when the user asks about token trends, DeFi protocols, wallet holdings, project due diligence, Twitter/X crypto sentiment, or deeper market analysis.
-compatibility: Requires network access and one payment credential path (HEURIST_API_KEY, WALLET_PRIVATE_KEY, or INFLOW_USER_ID and INFLOW_PRIVATE_KEY).
+compatibility: Requires network access and curl or equivalent HTTP client.
 metadata:
   author: heurist-network
   docs: https://docs.heurist.ai
@@ -79,14 +79,14 @@ At least one payment path must be configured. Do not call Mesh APIs until setup 
 - x402 path: `WALLET_PRIVATE_KEY` is set, starts with `0x`, and is 66 characters
 - Inflow path: `INFLOW_USER_ID` and `INFLOW_PRIVATE_KEY` are set and non-empty
 
-If none are configured, stop and ask the user to finish payment setup before any API call.
+**If none are configured, STOP and ask the user to set up a payment method. Do not make API calls without valid credentials.**
 
 ### Step 3: Fetch schema before tool calls
 
 Use `mesh_schema` to confirm parameter names, required fields, and pricing before calling any tool:
 
 ```
-GET https://mesh.heurist.xyz/mesh_schema?agent_id=TokenResolverAgent&agent_id=CoinGeckoTokenInfoAgent
+GET https://mesh.heurist.xyz/mesh_schema?agent_id=TokenResolverAgent&agent_id=TrendingTokenAgent
 ```
 
 Default pricing is in credits (`1 credit = $0.01`). Add `&pricing=usd` for USD-denominated prices with x402 or Inflow.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: heurist-mesh-skill
 description: Access real-time crypto token data, DeFi analytics, wallet intelligence, project research, and blockchain insights through Heurist Mesh agents. Use when the user asks about token trends, DeFi protocols, wallet holdings, project due diligence, Twitter/X crypto sentiment, or deeper market analysis.
+compatibility: Requires network access and one payment credential path (HEURIST_API_KEY, WALLET_PRIVATE_KEY, or INFLOW_USER_ID and INFLOW_PRIVATE_KEY).
+metadata:
+  author: heurist-network
+  docs: https://docs.heurist.ai
 ---
 
 # Heurist Mesh

--- a/SKILL.md
+++ b/SKILL.md
@@ -109,6 +109,32 @@ curl -X POST https://mesh.heurist.xyz/mesh_request \
 - Use `raw_data_only: true` when the user asks for direct machine-readable payloads or downstream parsing
 - Use `raw_data_only: false` (or omit) when the user asks for interpreted prose from the agent
 
+## Examples
+
+### Example 1: Trending tokens
+
+User asks: "What tokens are trending right now?"
+
+1. Fetch schema: `GET /mesh_schema?agent_id=TrendingTokenAgent`
+2. Call tool: `TrendingTokenAgent.get_trending_tokens` with `raw_data_only: true`
+3. Return top tokens with key metrics, then summarize notable moves
+
+### Example 2: Token profile lookup
+
+User asks: "Analyze ETH setup."
+
+1. Fetch schema: `GET /mesh_schema?agent_id=TokenResolverAgent`
+2. Resolve candidate: `TokenResolverAgent.token_search` with `query: "ETH"`
+3. If ambiguous, ask user which candidate they mean; otherwise call `TokenResolverAgent.token_profile`
+
+### Example 3: Deep market question
+
+User asks: "Give me a deep view on current market risk and opportunity."
+
+1. Gather fresh context with `TrendingTokenAgent.get_market_summary`
+2. Run `AskHeuristAgent.ask_heurist` with the user question plus gathered context
+3. If asynchronous, poll with `AskHeuristAgent.check_job_status` until complete
+
 ## Discover More Agents
 
 **All agents:** Fetch `https://mesh.heurist.ai/metadata.json` for the full registry. We have 30+ specialized crypto analytics agents covering use cases such as: reading address transaction history, reading transaction details from hash, tracing USDC on Base, detailed Coingecko data, Firecrawl scraping, GoPlus security screening, checking Twitter account influence via Moni, using SQL to query blockchain data, etc.

--- a/SKILL.md
+++ b/SKILL.md
@@ -158,6 +158,7 @@ Research Progress:
 
 ## Discover More Agents
 
-**All agents:** Fetch `https://mesh.heurist.ai/metadata.json` for the full registry. We have 30+ specialized crypto analytics agents covering use cases such as: reading address transaction history, reading transaction details from hash, tracing USDC on Base, detailed Coingecko data, Firecrawl scraping, GoPlus security screening, checking Twitter account influence via Moni, using SQL to query blockchain data, etc.
+For full agent discovery workflow and examples, see [references/discover-agents.md](references/discover-agents.md).
 
-**x402-enabled agents only:** Fetch `https://mesh.heurist.xyz/x402/agents` for agents supporting on-chain USDC payment on Base.
+- All agents: `https://mesh.heurist.ai/metadata.json`
+- x402-enabled agents: `https://mesh.heurist.xyz/x402/agents`

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,6 +11,16 @@ metadata:
 
 Heurist Mesh is an open network of modular AI agent tools for cryptocurrency and blockchain data. All features accessible via a unified REST API.
 
+## When to Use
+
+Use this skill when the user asks for crypto or Web3 intelligence that benefits from live data retrieval, including:
+
+- Token discovery, trending pairs, and market snapshots
+- DeFi protocol metrics, chain-level activity, and revenue/TVL comparisons
+- Wallet holdings, address labels, or NFT portfolio lookups
+- Twitter/X signal checks, project due diligence, and ecosystem research
+- Deeper market questions that should escalate to `AskHeuristAgent`
+
 ## Recommended Agents and Tools
 
 **TrendingTokenAgent** — Trending tokens and market summary

--- a/SKILL.md
+++ b/SKILL.md
@@ -104,6 +104,11 @@ curl -X POST https://mesh.heurist.xyz/mesh_request \
 # See references/x402-payment.md for the full cast-based flow and helper script
 ```
 
+`raw_data_only` usage:
+
+- Use `raw_data_only: true` when the user asks for direct machine-readable payloads or downstream parsing
+- Use `raw_data_only: false` (or omit) when the user asks for interpreted prose from the agent
+
 ## Discover More Agents
 
 **All agents:** Fetch `https://mesh.heurist.ai/metadata.json` for the full registry. We have 30+ specialized crypto analytics agents covering use cases such as: reading address transaction history, reading transaction details from hash, tracing USDC on Base, detailed Coingecko data, Firecrawl scraping, GoPlus security screening, checking Twitter account influence via Moni, using SQL to query blockchain data, etc.

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 Heurist Mesh is an open network of modular AI agent tools for cryptocurrency and blockchain data. All features accessible via a unified REST API.
 
-### Recommended Agents and Tools
+## Recommended Agents and Tools
 
 **TrendingTokenAgent** — Trending tokens and market summary
 - `get_trending_tokens` — Get trending tokens most talked about and traded on CEXs and DEXs

--- a/SKILL.md
+++ b/SKILL.md
@@ -63,64 +63,35 @@ Use this skill when the user asks for crypto or Web3 intelligence that benefits 
 - `ask_heurist` — Submit a crypto question (normal or deep analysis mode)
 - `check_job_status` — Check status of a pending analysis job
 
-## Setup (MUST complete before making any API calls)
+## Setup (must complete before making API calls)
 
-You need at least one payment method configured. **DO NOT call any Mesh tool APIs until setup is verified.**
+At least one payment path must be configured. Do not call Mesh APIs until setup is verified.
 
-### Step 1: Choose a payment method
+### Step 1: Choose one payment path
 
-**Option A: Heurist API Key (Recommended — simplest)**
+- **API key (recommended):** Set `HEURIST_API_KEY` in `.env`. Setup and free-credit flow: [references/heurist-api-key.md](references/heurist-api-key.md)
+- **x402 on Base:** Set `WALLET_PRIVATE_KEY` in `.env`. Signed payment flow: [references/x402-payment.md](references/x402-payment.md)
+- **Inflow:** Set `INFLOW_USER_ID` and `INFLOW_PRIVATE_KEY` in `.env`. Buyer setup and approval flow: [references/inflow-payment.md](references/inflow-payment.md)
 
-1. Get an API key via ONE of:
-   - Purchase credits at https://heurist.ai/credits
-   - OR Claim 100 free credits via tweet (see [references/heurist-api-key.md](references/heurist-api-key.md))
-2. Store the key in `.env` in the project root:
-   ```
-   HEURIST_API_KEY=your-api-key-here
-   ```
-3. All API calls use `Authorization: Bearer $HEURIST_API_KEY`
+### Step 2: Verify setup in `.env`
 
-**Option B: x402 On-Chain Payment (USDC on Base)**
+- API key path: `HEURIST_API_KEY` is set and non-empty
+- x402 path: `WALLET_PRIVATE_KEY` is set, starts with `0x`, and is 66 characters
+- Inflow path: `INFLOW_USER_ID` and `INFLOW_PRIVATE_KEY` are set and non-empty
 
-1. You need a wallet private key with USDC balance on Base.
-2. Store the key in `.env` in the project root:
-   ```
-   WALLET_PRIVATE_KEY=0x...your-private-key
-   ```
-3. See [references/x402-payment.md](references/x402-payment.md) for the payment flow using `cast` (Foundry).
+If none are configured, stop and ask the user to finish payment setup before any API call.
 
-**Option C: Inflow Payment Platform (USDC via Inflow)**
+### Step 3: Fetch schema before tool calls
 
-1. If you already have Inflow credentials, store them in `.env`:
-   ```
-   INFLOW_USER_ID=your-buyer-user-id
-   INFLOW_PRIVATE_KEY=your-buyer-private-key
-   ```
-2. If not, create a buyer account and attach email — see [references/inflow-payment.md](references/inflow-payment.md) for one-time setup.
-3. Inflow uses a two-call payment flow (create request → user approves → execute). See [references/inflow-payment.md](references/inflow-payment.md) for the full flow.
-
-### Step 2: Verify setup
-
-Check that credentials are configured before proceeding:
-
-- **API Key path:** Read `.env` and confirm `HEURIST_API_KEY` is set and non-empty.
-- **x402 path:** Read `.env` and confirm `WALLET_PRIVATE_KEY` is set, starts with `0x`, and is 66 characters.
-- **Inflow path:** Read `.env` and confirm `INFLOW_USER_ID` and `INFLOW_PRIVATE_KEY` are set and non-empty.
-
-**If neither is configured, STOP and ask the user to set up a payment method. Do not make API calls without valid credentials.**
-
-### Step 3: Make API calls
-
-Once you have either Heurist API key or x402 wallet private key or Inflow key, you can make API calls. You should understand the tool schema and the parameters of tools you want before calling it.
-
-To fetch tool schema, use `mesh_schema` API:
+Use `mesh_schema` to confirm parameter names, required fields, and pricing before calling any tool:
 
 ```
 GET https://mesh.heurist.xyz/mesh_schema?agent_id=TokenResolverAgent&agent_id=CoinGeckoTokenInfoAgent
 ```
-Default pricing is in credits. 1 credit worth $0.01. Add `&pricing=usd` to get prices in USD instead of credits when using x402 or Inflow. Returns each tool's parameters (name, type, description, required/optional) and per-tool price.
 
-Then use the credentials in requests:
+Default pricing is in credits (`1 credit = $0.01`). Add `&pricing=usd` for USD-denominated prices with x402 or Inflow.
+
+Then use configured credentials in requests:
 
 ```bash
 # With API key

--- a/SKILL.md
+++ b/SKILL.md
@@ -135,6 +135,19 @@ User asks: "Give me a deep view on current market risk and opportunity."
 2. Run `AskHeuristAgent.ask_heurist` with the user question plus gathered context
 3. If asynchronous, poll with `AskHeuristAgent.check_job_status` until complete
 
+## Multi-Agent Workflow
+
+For broad research requests, use this sequence and track progress:
+
+```
+Research Progress:
+- [ ] Step 1: Resolve entities (token/project/wallet) with TokenResolverAgent or ProjectKnowledgeAgent
+- [ ] Step 2: Pull market + DeFi context with TrendingTokenAgent and DefiLlamaAgent
+- [ ] Step 3: Pull social context with TwitterIntelligenceAgent
+- [ ] Step 4: Synthesize with AskHeuristAgent or CaesarResearchAgent
+- [ ] Step 5: Return a structured answer with assumptions and confidence
+```
+
 ## Discover More Agents
 
 **All agents:** Fetch `https://mesh.heurist.ai/metadata.json` for the full registry. We have 30+ specialized crypto analytics agents covering use cases such as: reading address transaction history, reading transaction details from hash, tracing USDC on Base, detailed Coingecko data, Firecrawl scraping, GoPlus security screening, checking Twitter account influence via Moni, using SQL to query blockchain data, etc.

--- a/SKILL.md
+++ b/SKILL.md
@@ -148,6 +148,14 @@ Research Progress:
 - [ ] Step 5: Return a structured answer with assumptions and confidence
 ```
 
+## Error Handling
+
+- `401`/`403`: Treat as credential issue; ask user to re-check `.env` values and do not continue calls with the same secret
+- `402`: Payment required; follow the selected payment path (`HEURIST_API_KEY`, x402 flow, or Inflow approval)
+- `status: "payment_pending"` (Inflow): ask for approval status, then retry with backoff
+- `429` or `5xx`: retry with exponential backoff and cap retries before surfacing failure details
+- Ambiguous `token_search` results: request user disambiguation before calling expensive downstream tools
+
 ## Discover More Agents
 
 **All agents:** Fetch `https://mesh.heurist.ai/metadata.json` for the full registry. We have 30+ specialized crypto analytics agents covering use cases such as: reading address transaction history, reading transaction details from hash, tracing USDC on Base, detailed Coingecko data, Firecrawl scraping, GoPlus security screening, checking Twitter account influence via Moni, using SQL to query blockchain data, etc.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: heurist-mesh-skill
-description: Real-time crypto token data, DeFi analytics, blockchain data, Twitter/X social intelligence, enhanced web search, crypto project search all in one Skill. For in-depths topics, "Ask Heurist" agent can handle market trends, trading strategies, macro news, and deep research.
+description: Access real-time crypto token data, DeFi analytics, wallet intelligence, project research, and blockchain insights through Heurist Mesh agents. Use when the user asks about token trends, DeFi protocols, wallet holdings, project due diligence, Twitter/X crypto sentiment, or deeper market analysis.
 ---
 
 # Heurist Mesh

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 # Heurist Mesh
 
-Heurist Mesh is an open network of modular AI agent tools for cryptocurrency and blockchain data. All features accessible via a unified REST API.
+Heurist Mesh is an open network of modular AI agent tools for cryptocurrency and blockchain data, accessible via a unified REST API.
 
 ## When to Use
 
@@ -83,7 +83,7 @@ At least one payment path must be configured. Do not call Mesh APIs until setup 
 
 ### Step 3: Fetch schema before tool calls
 
-Use `mesh_schema` to confirm parameter names, required fields, and pricing before calling any tool:
+Use `mesh_schema` to confirm parameter names, required fields, and pricing before calling any tool. Cache the result per agent for the session — schemas do not change between calls:
 
 ```
 GET https://mesh.heurist.xyz/mesh_schema?agent_id=TokenResolverAgent&agent_id=TrendingTokenAgent

--- a/references/discover-agents.md
+++ b/references/discover-agents.md
@@ -1,0 +1,28 @@
+# Discover More Heurist Mesh Agents
+
+Use these endpoints to discover available agents and choose the right tools for a request.
+
+## Registry Endpoints
+
+- All agents: `https://mesh.heurist.ai/metadata.json`
+- x402-enabled agents: `https://mesh.heurist.xyz/x402/agents`
+
+## Discovery Workflow
+
+1. Fetch the full registry from `metadata.json`
+2. Filter agents by user intent (token intel, DeFi analytics, social signal, wallet analysis, deep research)
+3. Fetch schemas for a shortlist with `mesh_schema` using repeated `agent_id` params
+4. Compare parameter requirements and per-tool pricing before execution
+
+## Example
+
+```bash
+# Pull full agent registry
+curl -sS https://mesh.heurist.ai/metadata.json
+
+# Pull x402-capable agents only
+curl -sS https://mesh.heurist.xyz/x402/agents
+
+# Fetch schemas for multiple candidates in one call
+curl -sS "https://mesh.heurist.xyz/mesh_schema?agent_id=TokenResolverAgent&agent_id=DefiLlamaAgent&agent_id=AskHeuristAgent"
+```


### PR DESCRIPTION
## Summary
- Add Skills CLI install instructions to `README.md` so users can install with `npx skills add heurist-network/heurist-mesh-skill`.
- Refactor `SKILL.md` for better activation and execution quality: clearer description triggers, explicit "When to Use", concise setup with progressive disclosure, examples, workflow checklist, and error handling.
- Move agent-discovery details into `references/discover-agents.md` and keep `SKILL.md` focused on high-signal runtime instructions.

## Why
- Improve skill discoverability and selection reliability by aligning metadata and structure with agent-skills authoring guidance.
- Reduce context overhead while preserving detail through one-level reference files.
- Make runtime behavior more deterministic (credentials, tool-call sequence, recovery behavior, and response mode selection).

## Reference Sources Used
- `vercel-labs/skills` README and discovery conventions
- Anthropic: Skill authoring best practices
- agentskills.io specification
- community guide patterns from `zebbern/agent-skills-guide` and `awesome-agent-skills`